### PR TITLE
feat: ULIDの保存・検証をサイトごとに分離

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # timed-access-app
 
-時限式アクセストークン管理アプリ。失効日時を設定してULIDを発行し、その時刻になるとトークンが自動で失効します。発行・検証はAPIが担い、デスクトップアプリからCRUD操作ができます。
+時限式アクセストークン管理アプリ。サイトごとに失効日時を設定してULIDを発行し、その時刻になるとトークンが自動で失効します。発行・検証はAPIが担い、デスクトップアプリからCRUD操作ができます。
 
 ## 構成
 
@@ -14,6 +14,7 @@ Deno Workspaceで3つのパッケージを管理しています。
 
 - ULIDは `@std/ulid` で生成し、Deno KVの `expireIn`
   により失効日時ちょうどにレコードが自動削除されます
+- トークンはサイト名（英小文字・数字・ハイフンのスラッグ）ごとに保存・検証されます
 - 依存関係はすべてJSRから取得しています
 
 ## セットアップ
@@ -126,14 +127,18 @@ deno task desktop:icon   # icon.png と icon.ico を再生成
 `TIMED_ACCESS_API_KEY`
 と同じ値が必要です。検証（`/verify`）は外部アプリからの利用を想定しているため、認証不要でCORS許可（`Access-Control-Allow-Origin: *`）です。
 
-| メソッド | パス          | 認証 | 説明                                                               |
-| -------- | ------------- | ---- | ------------------------------------------------------------------ |
-| `POST`   | `/tokens`     | 必要 | トークン発行。`{ "name"?: string, "expiresAt": string(ISO 8601) }` |
-| `GET`    | `/tokens`     | 必要 | 有効なトークンの一覧                                               |
-| `GET`    | `/tokens/:id` | 必要 | トークンの取得（失効済みは404）                                    |
-| `PATCH`  | `/tokens/:id` | 必要 | 表示名・失効日時の更新                                             |
-| `DELETE` | `/tokens/:id` | 必要 | トークンの即時失効                                                 |
-| `GET`    | `/verify/:id` | 不要 | トークン検証。`{ "valid": boolean, "token"?: TokenRecord }`        |
+| メソッド | パス                | 認証 | 説明                                                                               |
+| -------- | ------------------- | ---- | ---------------------------------------------------------------------------------- |
+| `POST`   | `/tokens`           | 必要 | トークン発行。`{ "site": string, "name"?: string, "expiresAt": string(ISO 8601) }` |
+| `GET`    | `/tokens`           | 必要 | 有効なトークンの一覧。`?site=` でサイト絞り込み                                    |
+| `GET`    | `/tokens/:site/:id` | 必要 | トークンの取得（失効済みは404）                                                    |
+| `PATCH`  | `/tokens/:site/:id` | 必要 | 表示名・失効日時の更新                                                             |
+| `DELETE` | `/tokens/:site/:id` | 必要 | トークンの即時失効                                                                 |
+| `GET`    | `/verify/:site/:id` | 不要 | トークン検証。`{ "valid": boolean, "token"?: TokenRecord }`                        |
+
+`site` はトークンを使うサイトを区別するスラッグで、英小文字・数字・ハイフン
+1〜64文字（`^[a-z0-9-]{1,64}$`）です。発行時に指定したサイト名と一致するパスで
+のみ検証が通るため、同じAPIを複数サイトで使い分けられます。
 
 ### 外部アプリからの検証
 
@@ -141,7 +146,7 @@ deno task desktop:icon   # icon.png と icon.ico を再生成
 
 ```ts
 const res = await fetch(
-  `https://your-api.example.com/verify/${ulid}`,
+  `https://your-api.example.com/verify/${siteName}/${ulid}`,
 );
 const { valid } = await res.json();
 if (valid) {
@@ -149,7 +154,8 @@ if (valid) {
 }
 ```
 
-- 失効日時を過ぎたULIDや削除済みのULIDは `{ "valid": false }` になります
+- 失効日時を過ぎたULIDや削除済みのULID、発行時と異なるサイト名での検証は
+  `{ "valid": false }` になります
 - レスポンスには `Cache-Control: no-store`
   が付き、判定結果はキャッシュされません
 - 存在しないIDでも200で `{ "valid": false }`
@@ -177,6 +183,7 @@ if (valid) {
 ```json
 {
   "id": "01JZ0000000000000000000000",
+  "site": "blog",
   "name": "社外向け共有リンク",
   "createdAt": "2026-07-04T03:00:00.000Z",
   "expiresAt": "2026-07-05T03:00:00.000Z"

--- a/api/app.ts
+++ b/api/app.ts
@@ -3,7 +3,11 @@ import type { Context } from "@hono/hono";
 import { cors } from "@hono/hono/cors";
 import { HTTPException } from "@hono/hono/http-exception";
 import { STATUS_CODE } from "@std/http/status";
-import type { TokenCreateInput, TokenUpdateInput } from "../shared/mod.ts";
+import {
+  SITE_NAME_PATTERN,
+  type TokenCreateInput,
+  type TokenUpdateInput,
+} from "../shared/mod.ts";
 import { requireApiKey } from "./middleware/api_key.ts";
 import { rateLimit, type RateLimitOptions } from "./middleware/rate_limit.ts";
 import type { TokenStore } from "./store.ts";
@@ -41,6 +45,19 @@ const parseExpiresAt = (value: unknown): Date => {
   return date;
 };
 
+/**
+ * サイト名の入力値を検証する
+ * @throws {HTTPException} スラッグとして不正な場合は400
+ */
+const parseSite = (value: unknown): string => {
+  if (typeof value !== "string" || !SITE_NAME_PATTERN.test(value)) {
+    throw new HTTPException(STATUS_CODE.BadRequest, {
+      message: "site は英小文字・数字・ハイフン1〜64文字で指定してください",
+    });
+  }
+  return value;
+};
+
 const tokenNotFound = () =>
   new HTTPException(STATUS_CODE.NotFound, {
     message: "指定されたトークンは存在しないか、既に失効しています",
@@ -74,6 +91,7 @@ export const createApp = (store: TokenStore, options: AppOptions = {}) => {
   app.post("/tokens", async (ctx) => {
     const body = await parseJsonBody<TokenCreateInput>(ctx);
     const token = await store.create({
+      site: parseSite(body.site),
       name: body.name,
       expiresAt: parseExpiresAt(body.expiresAt),
     });
@@ -81,37 +99,51 @@ export const createApp = (store: TokenStore, options: AppOptions = {}) => {
   });
 
   app.get("/tokens", async (ctx) => {
-    return ctx.json({ tokens: await store.list() });
-  });
-
-  app.get("/tokens/:id", async (ctx) => {
-    const token = await store.get(ctx.req.param("id"));
-    if (token === null) throw tokenNotFound();
-    return ctx.json(token);
-  });
-
-  app.patch("/tokens/:id", async (ctx) => {
-    const body = await parseJsonBody<TokenUpdateInput>(ctx);
-    const token = await store.update(ctx.req.param("id"), {
-      name: body.name,
-      expiresAt: body.expiresAt === undefined
-        ? undefined
-        : parseExpiresAt(body.expiresAt),
+    const site = ctx.req.query("site");
+    return ctx.json({
+      tokens: await store.list(
+        site === undefined ? undefined : parseSite(site),
+      ),
     });
+  });
+
+  app.get("/tokens/:site/:id", async (ctx) => {
+    const token = await store.get(ctx.req.param("site"), ctx.req.param("id"));
     if (token === null) throw tokenNotFound();
     return ctx.json(token);
   });
 
-  app.delete("/tokens/:id", async (ctx) => {
-    const deleted = await store.delete(ctx.req.param("id"));
+  app.patch("/tokens/:site/:id", async (ctx) => {
+    const body = await parseJsonBody<TokenUpdateInput>(ctx);
+    const token = await store.update(
+      ctx.req.param("site"),
+      ctx.req.param("id"),
+      {
+        name: body.name,
+        expiresAt: body.expiresAt === undefined
+          ? undefined
+          : parseExpiresAt(body.expiresAt),
+      },
+    );
+    if (token === null) throw tokenNotFound();
+    return ctx.json(token);
+  });
+
+  app.delete("/tokens/:site/:id", async (ctx) => {
+    const deleted = await store.delete(
+      ctx.req.param("site"),
+      ctx.req.param("id"),
+    );
     if (!deleted) throw tokenNotFound();
     return ctx.body(null, STATUS_CODE.NoContent);
   });
 
-  app.get("/verify/:id", async (ctx) => {
+  app.get("/verify/:site/:id", async (ctx) => {
     // 有効性の判定結果が中間キャッシュに残らないようにする
     ctx.header("cache-control", "no-store");
-    return ctx.json(await store.verify(ctx.req.param("id")));
+    return ctx.json(
+      await store.verify(ctx.req.param("site"), ctx.req.param("id")),
+    );
   });
 
   app.notFound((ctx) =>

--- a/api/app_test.ts
+++ b/api/app_test.ts
@@ -11,6 +11,8 @@ import { TokenStore } from "./store.ts";
 const API_KEY = "test-api-key";
 const AUTH_HEADERS = { [API_KEY_HEADER]: API_KEY };
 
+const SITE = "blog";
+
 const withApp = async (
   fn: (app: ReturnType<typeof createApp>) => Promise<void>,
   options?: Parameters<typeof createApp>[1],
@@ -27,11 +29,13 @@ const withApp = async (
 const createToken = async (
   app: ReturnType<typeof createApp>,
   expiresAt: Date,
+  site = SITE,
 ): Promise<TokenRecord> => {
   const res = await app.request("/tokens", {
     method: "POST",
     headers: AUTH_HEADERS,
     body: JSON.stringify({
+      site,
       name: "テスト",
       expiresAt: expiresAt.toISOString(),
     }),
@@ -57,6 +61,7 @@ Deno.test("POST /tokens: トークンを発行する", () =>
   withApp(async (app) => {
     const token = await createToken(app, new Date(Date.now() + 60_000));
     assertMatch(token.id, /^[0-9A-HJKMNP-TV-Z]{26}$/);
+    assertEquals(token.site, SITE);
     assertEquals(token.name, "テスト");
   }));
 
@@ -66,7 +71,23 @@ Deno.test("POST /tokens: 不正な失効日時は400", () =>
       const res = await app.request("/tokens", {
         method: "POST",
         headers: AUTH_HEADERS,
-        body: JSON.stringify({ expiresAt }),
+        body: JSON.stringify({ site: SITE, expiresAt }),
+      });
+      assertEquals(res.status, 400);
+      await res.body?.cancel();
+    }
+  }));
+
+Deno.test("POST /tokens: 不正なサイト名は400", () =>
+  withApp(async (app) => {
+    const expiresAt = new Date(Date.now() + 60_000).toISOString();
+    for (
+      const site of [undefined, "", "Blog", "日本語", "a b", "a".repeat(65)]
+    ) {
+      const res = await app.request("/tokens", {
+        method: "POST",
+        headers: AUTH_HEADERS,
+        body: JSON.stringify({ site, expiresAt }),
       });
       assertEquals(res.status, 400);
       await res.body?.cancel();
@@ -82,21 +103,54 @@ Deno.test("GET /tokens: 発行済みトークンを一覧する", () =>
     assertEquals(await res.json(), { tokens: [token] });
   }));
 
-Deno.test("GET /tokens/:id: 存在しないトークンは404", () =>
+Deno.test("GET /tokens?site=: サイトで絞り込んで一覧する", () =>
   withApp(async (app) => {
-    const res = await app.request("/tokens/unknown", {
+    const blogToken = await createToken(
+      app,
+      new Date(Date.now() + 60_000),
+      "blog",
+    );
+    await createToken(app, new Date(Date.now() + 60_000), "portfolio");
+
+    const res = await app.request("/tokens?site=blog", {
+      headers: AUTH_HEADERS,
+    });
+    assertEquals(res.status, 200);
+    assertEquals(await res.json(), { tokens: [blogToken] });
+
+    const invalid = await app.request("/tokens?site=Blog!", {
+      headers: AUTH_HEADERS,
+    });
+    assertEquals(invalid.status, 400);
+    await invalid.body?.cancel();
+  }));
+
+Deno.test("GET /tokens/:site/:id: 存在しないトークンは404", () =>
+  withApp(async (app) => {
+    const res = await app.request(`/tokens/${SITE}/unknown`, {
       headers: AUTH_HEADERS,
     });
     assertEquals(res.status, 404);
     await res.body?.cancel();
   }));
 
-Deno.test("PATCH /tokens/:id: 表示名と失効日時を更新する", () =>
+Deno.test("GET /tokens/:site/:id: サイトが異なると404", () =>
+  withApp(async (app) => {
+    const token = await createToken(app, new Date(Date.now() + 60_000));
+
+    const res = await app.request(`/tokens/other-site/${token.id}`, {
+      headers: AUTH_HEADERS,
+    });
+    assertEquals(res.status, 404);
+    await res.body?.cancel();
+  }));
+
+Deno.test("PATCH /tokens/:site/:id: 表示名と失効日時を更新する", () =>
   withApp(async (app) => {
     const token = await createToken(app, new Date(Date.now() + 60_000));
     const newExpiresAt = new Date(Date.now() + 120_000);
 
-    const res = await app.request(`/tokens/${token.id}`, {
+    const res = await app.request(`/tokens/${SITE}/${token.id}`, {
       method: "PATCH",
       headers: AUTH_HEADERS,
       body: JSON.stringify({
@@ -111,60 +165,69 @@ Deno.test("PATCH /tokens/:id: 表示名と失効日時を更新する", () =>
     assertEquals(updated.expiresAt, newExpiresAt.toISOString());
   }));
 
-Deno.test("DELETE /tokens/:id: トークンを失効させる", () =>
+Deno.test("DELETE /tokens/:site/:id: トークンを失効させる", () =>
   withApp(async (app) => {
     const token = await createToken(app, new Date(Date.now() + 60_000));
 
-    const res = await app.request(`/tokens/${token.id}`, {
+    const res = await app.request(`/tokens/${SITE}/${token.id}`, {
       method: "DELETE",
       headers: AUTH_HEADERS,
     });
     assertEquals(res.status, 204);
 
-    const verifyRes = await app.request(`/verify/${token.id}`, {
+    const verifyRes = await app.request(`/verify/${SITE}/${token.id}`, {
       headers: AUTH_HEADERS,
     });
     const result: VerifyResult = await verifyRes.json();
     assertEquals(result, { valid: false });
   }));
 
-Deno.test("GET /verify/:id: 有効なトークンを検証できる", () =>
+Deno.test("GET /verify/:site/:id: 有効なトークンを検証できる", () =>
   withApp(async (app) => {
     const token = await createToken(app, new Date(Date.now() + 60_000));
 
-    const res = await app.request(`/verify/${token.id}`, {
+    const res = await app.request(`/verify/${SITE}/${token.id}`, {
       headers: AUTH_HEADERS,
     });
     assertEquals(res.status, 200);
     assertEquals(await res.json(), { valid: true, token });
   }));
 
-Deno.test("GET /verify/:id: APIキーなしの外部アプリからも検証できる", () =>
+Deno.test("GET /verify/:site/:id: サイトが異なるとvalid: false", () =>
   withApp(async (app) => {
     const token = await createToken(app, new Date(Date.now() + 60_000));
 
-    const res = await app.request(`/verify/${token.id}`);
+    const res = await app.request(`/verify/other-site/${token.id}`);
+    assertEquals(res.status, 200);
+    assertEquals(await res.json(), { valid: false });
+  }));
+
+Deno.test("GET /verify/:site/:id: APIキーなしの外部アプリからも検証できる", () =>
+  withApp(async (app) => {
+    const token = await createToken(app, new Date(Date.now() + 60_000));
+
+    const res = await app.request(`/verify/${SITE}/${token.id}`);
     assertEquals(res.status, 200);
     assertEquals(res.headers.get("access-control-allow-origin"), "*");
     assertEquals(res.headers.get("cache-control"), "no-store");
     assertEquals(await res.json(), { valid: true, token });
 
-    const invalid = await app.request("/verify/unknown");
+    const invalid = await app.request(`/verify/${SITE}/unknown`);
     assertEquals(invalid.status, 200);
     assertEquals(await invalid.json(), { valid: false });
   }));
 
-Deno.test("GET /verify/:id: レート制限を超えると429を返す", () =>
+Deno.test("GET /verify/:site/:id: レート制限を超えると429を返す", () =>
   withApp(async (app) => {
     const token = await createToken(app, new Date(Date.now() + 60_000));
 
     for (let i = 0; i < 2; i++) {
-      const ok = await app.request(`/verify/${token.id}`);
+      const ok = await app.request(`/verify/${SITE}/${token.id}`);
       assertEquals(ok.status, 200);
       await ok.body?.cancel();
     }
 
-    const blocked = await app.request(`/verify/${token.id}`);
+    const blocked = await app.request(`/verify/${SITE}/${token.id}`);
     assertEquals(blocked.status, 429);
     assertEquals(blocked.headers.get("retry-after"), "60");
     await blocked.body?.cancel();

--- a/api/store.ts
+++ b/api/store.ts
@@ -23,13 +23,13 @@ export class TokenStore {
   }
 
   /**
-   * ULIDを生成し、指定した失効日時付きで保存する
-   * @param input 表示名と失効日時
+   * ULIDを生成し、指定したサイト配下に失効日時付きで保存する
+   * @param input サイト名・表示名・失効日時
    * @returns 発行されたトークン
    * @throws {RangeError} 失効日時が現在以前の場合
    */
   async create(
-    input: { name?: string; expiresAt: Date },
+    input: { site: string; name?: string; expiresAt: Date },
   ): Promise<TokenRecord> {
     const now = new Date();
     const expireIn = input.expiresAt.getTime() - now.getTime();
@@ -39,26 +39,29 @@ export class TokenStore {
 
     const token: TokenRecord = {
       id: monotonicUlid(),
+      site: input.site,
       name: input.name?.trim() || DEFAULT_NAME,
       createdAt: now.toISOString(),
       expiresAt: input.expiresAt.toISOString(),
     };
 
     // 失効日時ちょうどにKVからも自動削除されるよう expireIn を設定
-    await this.#kv.set([KEY_PREFIX, token.id], token, { expireIn });
+    await this.#kv.set([KEY_PREFIX, token.site, token.id], token, {
+      expireIn,
+    });
 
     return token;
   }
 
   /**
-   * 有効なトークンを作成順（ULID順）で列挙する
+   * 有効なトークンをサイト名・作成順（ULID順）で列挙する
+   * @param site 指定した場合はそのサイトのトークンのみ列挙
    * @returns 有効なトークンの一覧
    */
-  async list(): Promise<TokenRecord[]> {
+  async list(site?: string): Promise<TokenRecord[]> {
     const tokens: TokenRecord[] = [];
-    for await (
-      const entry of this.#kv.list<TokenRecord>({ prefix: [KEY_PREFIX] })
-    ) {
+    const prefix = site === undefined ? [KEY_PREFIX] : [KEY_PREFIX, site];
+    for await (const entry of this.#kv.list<TokenRecord>({ prefix })) {
       // KVの自動削除は失効直後に反映されない場合があるため日時でも判定
       if (!isExpired(entry.value)) tokens.push(entry.value);
     }
@@ -67,27 +70,30 @@ export class TokenStore {
 
   /**
    * トークンを取得する
+   * @param site トークンが属するサイト名
    * @param id トークンのULID
    * @returns トークン。存在しないか失効済みなら null
    */
-  async get(id: string): Promise<TokenRecord | null> {
-    const entry = await this.#kv.get<TokenRecord>([KEY_PREFIX, id]);
+  async get(site: string, id: string): Promise<TokenRecord | null> {
+    const entry = await this.#kv.get<TokenRecord>([KEY_PREFIX, site, id]);
     if (entry.value === null || isExpired(entry.value)) return null;
     return entry.value;
   }
 
   /**
    * トークンの表示名・失効日時を更新する
+   * @param site トークンが属するサイト名
    * @param id トークンのULID
    * @param patch 更新内容（未指定の項目は維持）
    * @returns 更新後のトークン。存在しないか失効済みなら null
    * @throws {RangeError} 失効日時が現在以前の場合
    */
   async update(
+    site: string,
     id: string,
     patch: { name?: string; expiresAt?: Date },
   ): Promise<TokenRecord | null> {
-    const current = await this.get(id);
+    const current = await this.get(site, id);
     if (current === null) return null;
 
     const expiresAt = patch.expiresAt ?? new Date(current.expiresAt);
@@ -104,31 +110,33 @@ export class TokenStore {
         : patch.name.trim() || DEFAULT_NAME,
       expiresAt: expiresAt.toISOString(),
     };
-    await this.#kv.set([KEY_PREFIX, id], updated, { expireIn });
+    await this.#kv.set([KEY_PREFIX, site, id], updated, { expireIn });
 
     return updated;
   }
 
   /**
    * トークンを失効（削除）させる
+   * @param site トークンが属するサイト名
    * @param id トークンのULID
    * @returns 削除できたら true。存在しないか失効済みなら false
    */
-  async delete(id: string): Promise<boolean> {
-    const current = await this.get(id);
+  async delete(site: string, id: string): Promise<boolean> {
+    const current = await this.get(site, id);
     if (current === null) return false;
 
-    await this.#kv.delete([KEY_PREFIX, id]);
+    await this.#kv.delete([KEY_PREFIX, site, id]);
     return true;
   }
 
   /**
-   * トークンが有効か検証する
+   * トークンが指定サイトで有効か検証する
+   * @param site トークンが属するサイト名
    * @param id トークンのULID
    * @returns 検証結果。有効ならトークン情報も返す
    */
-  async verify(id: string): Promise<VerifyResult> {
-    const token = await this.get(id);
+  async verify(site: string, id: string): Promise<VerifyResult> {
+    const token = await this.get(site, id);
     return token === null ? { valid: false } : { valid: true, token };
   }
 }

--- a/api/store_test.ts
+++ b/api/store_test.ts
@@ -9,6 +9,8 @@ import { isExpired, TokenStore } from "./store.ts";
 
 const ULID_PATTERN = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 
+const SITE = "blog";
+
 const withStore = async (
   fn: (store: TokenStore, kv: Deno.Kv) => Promise<void>,
 ) => {
@@ -24,17 +26,19 @@ const withStore = async (
 const seedExpiredToken = async (kv: Deno.Kv): Promise<TokenRecord> => {
   const expired: TokenRecord = {
     id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+    site: SITE,
     name: "期限切れ",
     createdAt: new Date(Date.now() - 120_000).toISOString(),
     expiresAt: new Date(Date.now() - 60_000).toISOString(),
   };
-  await kv.set(["tokens", expired.id], expired);
+  await kv.set(["tokens", expired.site, expired.id], expired);
   return expired;
 };
 
 Deno.test("isExpired: 失効日時を過ぎたトークンをtrueと判定する", () => {
   const base = {
     id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+    site: SITE,
     name: "テスト",
     createdAt: new Date().toISOString(),
   };
@@ -54,20 +58,22 @@ Deno.test("isExpired: 失効日時を過ぎたトークンをtrueと判定する
   );
 });
 
-Deno.test("create: ULIDと失効日時を持つトークンを発行する", () =>
+Deno.test("create: ULIDと失効日時を持つトークンをサイト配下に発行する", () =>
   withStore(async (store) => {
     const expiresAt = new Date(Date.now() + 60_000);
-    const token = await store.create({ name: "テスト", expiresAt });
+    const token = await store.create({ site: SITE, name: "テスト", expiresAt });
 
     assertMatch(token.id, ULID_PATTERN);
+    assertEquals(token.site, SITE);
     assertEquals(token.name, "テスト");
     assertEquals(token.expiresAt, expiresAt.toISOString());
-    assertEquals(await store.get(token.id), token);
+    assertEquals(await store.get(SITE, token.id), token);
   }));
 
 Deno.test("create: 名前を省略すると既定の表示名になる", () =>
   withStore(async (store) => {
     const token = await store.create({
+      site: SITE,
       expiresAt: new Date(Date.now() + 60_000),
     });
     assertEquals(token.name, "無題のトークン");
@@ -76,7 +82,8 @@ Deno.test("create: 名前を省略すると既定の表示名になる", () =>
 Deno.test("create: 過去の失効日時では発行できない", () =>
   withStore(async (store) => {
     await assertRejects(
-      () => store.create({ expiresAt: new Date(Date.now() - 1_000) }),
+      () =>
+        store.create({ site: SITE, expiresAt: new Date(Date.now() - 1_000) }),
       RangeError,
     );
   }));
@@ -85,10 +92,12 @@ Deno.test("list: 有効なトークンのみを作成順で返す", () =>
   withStore(async (store, kv) => {
     await seedExpiredToken(kv);
     const first = await store.create({
+      site: SITE,
       name: "1つ目",
       expiresAt: new Date(Date.now() + 60_000),
     });
     const second = await store.create({
+      site: SITE,
       name: "2つ目",
       expiresAt: new Date(Date.now() + 120_000),
     });
@@ -96,21 +105,48 @@ Deno.test("list: 有効なトークンのみを作成順で返す", () =>
     assertEquals(await store.list(), [first, second]);
   }));
 
+Deno.test("list: サイトを指定するとそのサイトのトークンのみ返す", () =>
+  withStore(async (store) => {
+    const blogToken = await store.create({
+      site: "blog",
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const portfolioToken = await store.create({
+      site: "portfolio",
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    assertEquals(await store.list("blog"), [blogToken]);
+    assertEquals(await store.list("portfolio"), [portfolioToken]);
+    assertEquals(await store.list(), [blogToken, portfolioToken]);
+    assertEquals(await store.list("unknown"), []);
+  }));
+
 Deno.test("get: 失効済みトークンはnullを返す", () =>
   withStore(async (store, kv) => {
     const expired = await seedExpiredToken(kv);
-    assertEquals(await store.get(expired.id), null);
+    assertEquals(await store.get(SITE, expired.id), null);
+  }));
+
+Deno.test("get: サイトが異なるとnullを返す", () =>
+  withStore(async (store) => {
+    const token = await store.create({
+      site: SITE,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    assertEquals(await store.get("other-site", token.id), null);
   }));
 
 Deno.test("update: 表示名と失効日時を更新し、失効済みには適用しない", () =>
   withStore(async (store, kv) => {
     const token = await store.create({
+      site: SITE,
       name: "更新前",
       expiresAt: new Date(Date.now() + 60_000),
     });
     const newExpiresAt = new Date(Date.now() + 120_000);
 
-    const updated = await store.update(token.id, {
+    const updated = await store.update(SITE, token.id, {
       name: "更新後",
       expiresAt: newExpiresAt,
     });
@@ -119,39 +155,41 @@ Deno.test("update: 表示名と失効日時を更新し、失効済みには適�
     assertNotEquals(updated?.expiresAt, token.expiresAt);
 
     const expired = await seedExpiredToken(kv);
-    assertEquals(await store.update(expired.id, { name: "無効" }), null);
+    assertEquals(await store.update(SITE, expired.id, { name: "無効" }), null);
   }));
 
 Deno.test("update: nameの未指定は維持、空文字は既定名にリセットする", () =>
   withStore(async (store) => {
     const token = await store.create({
+      site: SITE,
       name: "元の名前",
       expiresAt: new Date(Date.now() + 60_000),
     });
 
     // name未指定 → 維持（失効日時だけ更新）
-    const kept = await store.update(token.id, {
+    const kept = await store.update(SITE, token.id, {
       expiresAt: new Date(Date.now() + 120_000),
     });
     assertEquals(kept?.name, "元の名前");
 
     // name="" → 既定名にリセット（createと同じ扱い）
-    const reset = await store.update(token.id, { name: "" });
+    const reset = await store.update(SITE, token.id, { name: "" });
     assertEquals(reset?.name, "無題のトークン");
 
     // 空白のみも既定名にリセット
-    const resetBlank = await store.update(token.id, { name: "   " });
+    const resetBlank = await store.update(SITE, token.id, { name: "   " });
     assertEquals(resetBlank?.name, "無題のトークン");
   }));
 
 Deno.test("update: 過去の失効日時には更新できない", () =>
   withStore(async (store) => {
     const token = await store.create({
+      site: SITE,
       expiresAt: new Date(Date.now() + 60_000),
     });
     await assertRejects(
       () =>
-        store.update(token.id, {
+        store.update(SITE, token.id, {
           expiresAt: new Date(Date.now() - 1_000),
         }),
       RangeError,
@@ -161,22 +199,34 @@ Deno.test("update: 過去の失効日時には更新できない", () =>
 Deno.test("delete: トークンを失効させ、二重削除はfalseを返す", () =>
   withStore(async (store) => {
     const token = await store.create({
+      site: SITE,
       expiresAt: new Date(Date.now() + 60_000),
     });
 
-    assertEquals(await store.delete(token.id), true);
-    assertEquals(await store.get(token.id), null);
-    assertEquals(await store.delete(token.id), false);
+    assertEquals(await store.delete(SITE, token.id), true);
+    assertEquals(await store.get(SITE, token.id), null);
+    assertEquals(await store.delete(SITE, token.id), false);
   }));
 
 Deno.test("verify: 有効ならトークン付き、無効ならvalid: falseを返す", () =>
   withStore(async (store, kv) => {
     const token = await store.create({
+      site: SITE,
       expiresAt: new Date(Date.now() + 60_000),
     });
     const expired = await seedExpiredToken(kv);
 
-    assertEquals(await store.verify(token.id), { valid: true, token });
-    assertEquals(await store.verify(expired.id), { valid: false });
-    assertEquals(await store.verify("存在しないID"), { valid: false });
+    assertEquals(await store.verify(SITE, token.id), { valid: true, token });
+    assertEquals(await store.verify(SITE, expired.id), { valid: false });
+    assertEquals(await store.verify(SITE, "存在しないID"), { valid: false });
+  }));
+
+Deno.test("verify: サイトが異なるとvalid: falseを返す", () =>
+  withStore(async (store) => {
+    const token = await store.create({
+      site: SITE,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    assertEquals(await store.verify("other-site", token.id), { valid: false });
   }));

--- a/desktop/api_client.ts
+++ b/desktop/api_client.ts
@@ -84,24 +84,38 @@ export class ApiClient {
     });
   }
 
-  getToken(id: string): Promise<TokenRecord> {
-    return this.#request(`/tokens/${encodeURIComponent(id)}`);
+  getToken(site: string, id: string): Promise<TokenRecord> {
+    return this.#request(
+      `/tokens/${encodeURIComponent(site)}/${encodeURIComponent(id)}`,
+    );
   }
 
-  updateToken(id: string, input: TokenUpdateInput): Promise<TokenRecord> {
-    return this.#request(`/tokens/${encodeURIComponent(id)}`, {
-      method: "PATCH",
-      body: JSON.stringify(input),
-    });
+  updateToken(
+    site: string,
+    id: string,
+    input: TokenUpdateInput,
+  ): Promise<TokenRecord> {
+    return this.#request(
+      `/tokens/${encodeURIComponent(site)}/${encodeURIComponent(id)}`,
+      {
+        method: "PATCH",
+        body: JSON.stringify(input),
+      },
+    );
   }
 
-  deleteToken(id: string): Promise<void> {
-    return this.#request(`/tokens/${encodeURIComponent(id)}`, {
-      method: "DELETE",
-    });
+  deleteToken(site: string, id: string): Promise<void> {
+    return this.#request(
+      `/tokens/${encodeURIComponent(site)}/${encodeURIComponent(id)}`,
+      {
+        method: "DELETE",
+      },
+    );
   }
 
-  verifyToken(id: string): Promise<VerifyResult> {
-    return this.#request(`/verify/${encodeURIComponent(id)}`);
+  verifyToken(site: string, id: string): Promise<VerifyResult> {
+    return this.#request(
+      `/verify/${encodeURIComponent(site)}/${encodeURIComponent(id)}`,
+    );
   }
 }

--- a/desktop/api_client_test.ts
+++ b/desktop/api_client_test.ts
@@ -36,9 +36,9 @@ Deno.test("ApiClient: baseUrl末尾のスラッシュは重複させない", () 
     assertEquals(calls[0], "http://localhost:8000/tokens");
   }));
 
-Deno.test("ApiClient: verifyのIDはURLエンコードされる", () =>
+Deno.test("ApiClient: verifyのサイト名とIDはURLエンコードされる", () =>
   withFetchSpy(async (calls) => {
     const client = new ApiClient("http://localhost:8000", "key");
-    await client.verifyToken("a/b");
-    assertEquals(calls[0], "http://localhost:8000/verify/a%2Fb");
+    await client.verifyToken("s/x", "a/b");
+    assertEquals(calls[0], "http://localhost:8000/verify/s%2Fx/a%2Fb");
   }));

--- a/desktop/app.tsx
+++ b/desktop/app.tsx
@@ -42,17 +42,19 @@ const redirectWithError = (ctx: Context, message: string) =>
 const redirectWithNotice = (ctx: Context, message: string) =>
   ctx.redirect(`/?notice=${encodeURIComponent(message)}`, 303);
 
-/** フォームから表示名と失効日時を取り出す */
+/** フォームからサイト名・表示名・失効日時を取り出す */
 const parseTokenForm = async (
   ctx: Context,
-): Promise<{ name: string; expiresAt: Date | null }> => {
+): Promise<{ site: string; name: string; expiresAt: Date | null }> => {
   const form = await ctx.req.parseBody();
+  const site = typeof form.site === "string" ? form.site.trim() : "";
   const name = typeof form.name === "string" ? form.name : "";
   const expiresLocal = typeof form.expires_at === "string"
     ? form.expires_at
     : "";
   const expiresAt = expiresLocal ? new Date(expiresLocal) : null;
   return {
+    site,
     name,
     expiresAt: expiresAt && !Number.isNaN(expiresAt.getTime())
       ? expiresAt
@@ -84,12 +86,16 @@ export const createDesktopApp = (client: ApiClient) => {
   });
 
   app.post("/tokens", async (ctx) => {
-    const { name, expiresAt } = await parseTokenForm(ctx);
+    const { site, name, expiresAt } = await parseTokenForm(ctx);
+    if (!site) {
+      return redirectWithError(ctx, "サイト名を入力してください");
+    }
     if (expiresAt === null) {
       return redirectWithError(ctx, "失効日時を入力してください");
     }
     try {
       const token = await client.createToken({
+        site,
         name,
         expiresAt: expiresAt.toISOString(),
       });
@@ -99,9 +105,12 @@ export const createDesktopApp = (client: ApiClient) => {
     }
   });
 
-  app.get("/tokens/:id/edit", async (ctx) => {
+  app.get("/tokens/:site/:id/edit", async (ctx) => {
     try {
-      const token = await client.getToken(ctx.req.param("id"));
+      const token = await client.getToken(
+        ctx.req.param("site"),
+        ctx.req.param("id"),
+      );
       return ctx.html(
         <EditPage token={token} error={ctx.req.query("error")} />,
       );
@@ -110,34 +119,37 @@ export const createDesktopApp = (client: ApiClient) => {
     }
   });
 
-  app.post("/tokens/:id/edit", async (ctx) => {
+  app.post("/tokens/:site/:id/edit", async (ctx) => {
+    const site = ctx.req.param("site");
     const id = ctx.req.param("id");
     const { name, expiresAt } = await parseTokenForm(ctx);
     if (expiresAt === null) {
       return ctx.redirect(
-        `/tokens/${id}/edit?error=${
+        `/tokens/${site}/${id}/edit?error=${
           encodeURIComponent("失効日時を入力してください")
         }`,
         303,
       );
     }
     try {
-      await client.updateToken(id, {
+      await client.updateToken(site, id, {
         name,
         expiresAt: expiresAt.toISOString(),
       });
       return redirectWithNotice(ctx, "トークンを更新しました");
     } catch (err) {
       return ctx.redirect(
-        `/tokens/${id}/edit?error=${encodeURIComponent(errorMessage(err))}`,
+        `/tokens/${site}/${id}/edit?error=${
+          encodeURIComponent(errorMessage(err))
+        }`,
         303,
       );
     }
   });
 
-  app.post("/tokens/:id/delete", async (ctx) => {
+  app.post("/tokens/:site/:id/delete", async (ctx) => {
     try {
-      await client.deleteToken(ctx.req.param("id"));
+      await client.deleteToken(ctx.req.param("site"), ctx.req.param("id"));
       return redirectWithNotice(ctx, "トークンを失効させました");
     } catch (err) {
       return redirectWithError(ctx, errorMessage(err));
@@ -145,13 +157,16 @@ export const createDesktopApp = (client: ApiClient) => {
   });
 
   app.get("/verify", async (ctx) => {
+    const site = ctx.req.query("site")?.trim();
     const id = ctx.req.query("id")?.trim();
-    if (!id) return ctx.html(<VerifyPage />);
+    if (!site || !id) return ctx.html(<VerifyPage site={site} id={id} />);
     try {
-      const result = await client.verifyToken(id);
-      return ctx.html(<VerifyPage id={id} result={result} />);
+      const result = await client.verifyToken(site, id);
+      return ctx.html(<VerifyPage site={site} id={id} result={result} />);
     } catch (err) {
-      return ctx.html(<VerifyPage id={id} error={errorMessage(err)} />);
+      return ctx.html(
+        <VerifyPage site={site} id={id} error={errorMessage(err)} />,
+      );
     }
   });
 

--- a/desktop/app_test.ts
+++ b/desktop/app_test.ts
@@ -5,6 +5,7 @@ import { createDesktopApp } from "./app.tsx";
 
 const sampleToken: TokenRecord = {
   id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+  site: "blog",
   name: "テスト",
   createdAt: new Date().toISOString(),
   expiresAt: new Date(Date.now() + 60_000).toISOString(),
@@ -37,6 +38,7 @@ const postToken = (
       ...headers,
     },
     body: new URLSearchParams({
+      site: "blog",
       name: "テスト",
       expires_at: "2027-01-01T12:00",
     }),

--- a/desktop/pages.tsx
+++ b/desktop/pages.tsx
@@ -47,6 +47,7 @@ const TokenTable = ({ tokens }: { tokens: TokenRecord[] }) => {
       <thead>
         <tr>
           <th>トークン（ULID）</th>
+          <th>サイト</th>
           <th>表示名</th>
           <th>発行日時</th>
           <th>失効日時</th>
@@ -58,6 +59,9 @@ const TokenTable = ({ tokens }: { tokens: TokenRecord[] }) => {
           <tr>
             <td>
               <code>{token.id}</code>
+            </td>
+            <td>
+              <code>{token.site}</code>
             </td>
             <td>{token.name}</td>
             <td>{formatDateTime(token.createdAt)}</td>
@@ -77,13 +81,13 @@ const TokenTable = ({ tokens }: { tokens: TokenRecord[] }) => {
                 </button>
                 <a
                   class={cx(styles.button, styles.buttonGhost)}
-                  href={`/tokens/${token.id}/edit`}
+                  href={`/tokens/${token.site}/${token.id}/edit`}
                 >
                   編集
                 </a>
                 <form
                   method="post"
-                  action={`/tokens/${token.id}/delete`}
+                  action={`/tokens/${token.site}/${token.id}/delete`}
                   data-confirm={`トークン「${token.name}」を失効させますか？`}
                 >
                   <button
@@ -114,6 +118,17 @@ export const IndexPage = ({ tokens, notice, error }: IndexPageProps) => (
     <section class={styles.card}>
       <h2>新しいトークンを発行</h2>
       <form class={styles.stackForm} method="post" action="/tokens">
+        <label>
+          サイト名
+          <input
+            type="text"
+            name="site"
+            required
+            pattern="[a-z0-9-]{1,64}"
+            title="英小文字・数字・ハイフン1〜64文字"
+            placeholder="例：blog"
+          />
+        </label>
         <label>
           表示名（任意）
           <input type="text" name="name" placeholder="例：社外向け共有リンク" />
@@ -149,12 +164,14 @@ export const EditPage = ({ token, error }: EditPageProps) => (
     <Banners error={error} />
     <section class={styles.card}>
       <h2>
-        トークンを編集：<code>{token.id}</code>
+        トークンを編集：<code>{token.id}</code>（サイト：<code>
+          {token.site}
+        </code>）
       </h2>
       <form
         class={styles.stackForm}
         method="post"
-        action={`/tokens/${token.id}/edit`}
+        action={`/tokens/${token.site}/${token.id}/edit`}
       >
         <label>
           表示名
@@ -184,17 +201,30 @@ export const EditPage = ({ token, error }: EditPageProps) => (
 );
 
 type VerifyPageProps = {
+  site?: string;
   id?: string;
   result?: VerifyResult;
   error?: string;
 };
 
-export const VerifyPage = ({ id, result, error }: VerifyPageProps) => (
+export const VerifyPage = ({ site, id, result, error }: VerifyPageProps) => (
   <Layout title="トークン検証">
     <Banners error={error} />
     <section class={styles.card}>
       <h2>トークンを検証</h2>
       <form class={styles.stackForm} method="get" action="/verify">
+        <label>
+          サイト名
+          <input
+            type="text"
+            name="site"
+            required
+            pattern="[a-z0-9-]{1,64}"
+            title="英小文字・数字・ハイフン1〜64文字"
+            value={site ?? ""}
+            placeholder="例：blog"
+          />
+        </label>
         <label>
           トークン（ULID）
           <input
@@ -220,7 +250,8 @@ export const VerifyPage = ({ id, result, error }: VerifyPageProps) => (
                   有効なトークンです
                 </p>
                 <p>
-                  <code>{result.token.id}</code>（{result.token.name}）
+                  <code>{result.token.id}</code>（サイト：{result.token.site}
+                  ／{result.token.name}）
                 </p>
                 <p>
                   失効日時：{formatDateTime(result.token.expiresAt)}（

--- a/shared/mod.ts
+++ b/shared/mod.ts
@@ -4,10 +4,15 @@ export const API_KEY_HEADER = "x-api-key";
 /** APIキーを設定する環境変数名 */
 export const API_KEY_ENV = "TIMED_ACCESS_API_KEY";
 
+/** サイト名として使えるスラッグ（URLセグメントになるため英小文字・数字・ハイフンのみ） */
+export const SITE_NAME_PATTERN = /^[a-z0-9-]{1,64}$/;
+
 /** 発行済みトークンの情報 */
 export type TokenRecord = {
   /** トークン本体となるULID */
   id: string;
+  /** トークンが属するサイト名（スラッグ） */
+  site: string;
   /** 管理用の表示名 */
   name: string;
   /** 発行日時（ISO 8601） */
@@ -18,6 +23,8 @@ export type TokenRecord = {
 
 /** トークン発行リクエストのボディ */
 export type TokenCreateInput = {
+  /** トークンが属するサイト名（スラッグ） */
+  site: string;
   name?: string;
   /** 失効日時（ISO 8601） */
   expiresAt: string;


### PR DESCRIPTION
- KVキーを ["tokens", site, id] に階層化し、検証を /verify/:site/:id に変更
- 管理APIも /tokens/:site/:id に変更し、POST /tokens で site を必須化
- サイト名はスラッグ（^[a-z0-9-]{1,64}$）としてshared/mod.tsで一元検証
- デスクトップUIにサイト名入力・サイト列を追加
- 旧 /verify/:id は廃止（既存トークンは失効による自然消滅を待つ）

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
